### PR TITLE
Adiciona o portal de noticias da Prefeitura de Resende e Portal da Cidade como fontes

### DIFF
--- a/src/Core/Extensions/StringExtensions.cs
+++ b/src/Core/Extensions/StringExtensions.cs
@@ -1,0 +1,22 @@
+namespace Core.Extensions;
+
+public static class StringExtensions
+{
+    public static string ReturnStringBetween(this string text, string start, string end, bool shouldTrim = false)
+    {
+        var startText = text.IndexOf(start, StringComparison.Ordinal) + start.Length;
+
+        // texto a partir do inicio informado
+        text = text.Substring(startText);
+
+        var endIndex = text.IndexOf(end, StringComparison.Ordinal);
+        var length = endIndex - 0;
+
+        var result = text.Substring(0, length);
+
+        if (shouldTrim)
+            result = result.Trim();
+
+        return result;
+    }
+}

--- a/src/Core/News/DataSources/AVozDaCidade.cs
+++ b/src/Core/News/DataSources/AVozDaCidade.cs
@@ -2,7 +2,7 @@
 
 namespace Core.News.DataSources;
 
-public class AVozDaCidade(HttpClient httpclient)
+public class AVozDaCidade(HttpClient httpclient) : IDataSource
 {
     private const string SourceName = "A Voz da Cidade";
     private const string SourceIconUrl = "https://avozdacidade.com/wp/wp-content/uploads/2022/08/LOGO-A-VOZ-DA-CIDADE.jpg";

--- a/src/Core/News/DataSources/DiarioDoVale.cs
+++ b/src/Core/News/DataSources/DiarioDoVale.cs
@@ -3,11 +3,11 @@
 
 namespace Core.News.DataSources;
 
-public class DiarioDoVale(HttpClient httpclient)
+public class DiarioDoVale(HttpClient httpclient) : IDataSource
 {
     private const string SourceName = "Diario do Vale";
     private const string SourceIconUrl = "https://diariodovale.com.br/wp-content/uploads/2024/04/logo-site-dv.png";
-    
+
     public async Task<News[]> GetNews()
     {
         var news = new List<News>();
@@ -20,45 +20,45 @@ public class DiarioDoVale(HttpClient httpclient)
     {
         var response = await httpclient.GetAsync("https://diariodovale.com.br/editoria/politica/");
         var html = await response.Content.ReadAsStringAsync();
-        
+
         var htmlDoc = new HtmlDocument();
-        htmlDoc.LoadHtml(html); 
+        htmlDoc.LoadHtml(html);
 
         var articles = htmlDoc.DocumentNode.SelectNodes("//article");
 
-        var newsCollections = await CreateNewsObject(articles, SubjectEnum.Politics);
+        var newsCollections = CreateNewsObject(articles, SubjectEnum.Politics);
         return newsCollections;
     }
-    
+
     private async Task<News[]> GetSportsNews()
     {
         var response = await httpclient.GetAsync("https://diariodovale.com.br/editoria/esporte/");
         var html = await response.Content.ReadAsStringAsync();
-        
+
         var htmlDoc = new HtmlDocument();
-        htmlDoc.LoadHtml(html); 
+        htmlDoc.LoadHtml(html);
 
         var articles = htmlDoc.DocumentNode.SelectNodes("//article");
 
-        var newsCollections = await CreateNewsObject(articles, SubjectEnum.Sports);
+        var newsCollections = CreateNewsObject(articles, SubjectEnum.Sports);
         return newsCollections;
     }
 
-    private Task<News[]> CreateNewsObject(HtmlNodeCollection articles, SubjectEnum subject)
+    private News[] CreateNewsObject(HtmlNodeCollection articles, SubjectEnum subject)
     {
         var newsCollection = new List<News>();
 
         foreach (var article in articles)
         {
             var title = article.SelectSingleNode(".//h2").InnerText;
-            var link = article.SelectSingleNode(".//h2//a").GetAttributeValue("href", ""); 
-            var date = article.SelectSingleNode(".//span//time").GetAttributeValue("datetime", ""); 
+            var link = article.SelectSingleNode(".//h2//a").GetAttributeValue("href", "");
+            var date = article.SelectSingleNode(".//span//time").GetAttributeValue("datetime", "");
             var content = article.SelectSingleNode(".//p").InnerText;
             var image = article.SelectSingleNode(".//div//a")?.GetAttributeValue("data-bgset", "") ?? null;
 
             title = HtmlEntity.DeEntitize(title);
             content = HtmlEntity.DeEntitize(content);
-            
+
             var news = new News(
                 title.Trim(),
                 content.Trim(),
@@ -70,10 +70,11 @@ public class DiarioDoVale(HttpClient httpclient)
                 image is null ? null : new Uri(image)
             );
 
-            if (news.Content.StartsWith("Resende", StringComparison.InvariantCultureIgnoreCase) || news.Content.StartsWith("Sul Fluminense", StringComparison.InvariantCultureIgnoreCase))
+            if (news.Content.StartsWith("Resende", StringComparison.InvariantCultureIgnoreCase) ||
+                news.Content.StartsWith("Sul Fluminense", StringComparison.InvariantCultureIgnoreCase))
                 newsCollection.Add(news);
         }
 
-        return Task.FromResult(newsCollection.ToArray());
+        return newsCollection.ToArray();
     }
 }

--- a/src/Core/News/DataSources/IDataSource.cs
+++ b/src/Core/News/DataSources/IDataSource.cs
@@ -1,0 +1,6 @@
+namespace Core.News.DataSources;
+
+public interface IDataSource
+{
+    Task<News[]> GetNews();
+}

--- a/src/Core/News/DataSources/JornalBeiraRio.cs
+++ b/src/Core/News/DataSources/JornalBeiraRio.cs
@@ -2,7 +2,7 @@ using HtmlAgilityPack;
 
 namespace Core.News.DataSources;
 
-public class JornalBeiraRio(HttpClient httpclient)
+public class JornalBeiraRio(HttpClient httpclient) : IDataSource
 {
     private const string SourceName = "Jornal Beira Rio";
     private const string SourceIconUrl = "https://jornalbeirario.com.br/portal/wp-content/uploads/2017/09/beira_rio_icon-150x150.png";
@@ -25,7 +25,7 @@ public class JornalBeiraRio(HttpClient httpclient)
 
         var articles = htmlDoc.DocumentNode.SelectNodes("//article");
 
-        var newsCollection = await CreateNewsObject(articles,SubjectEnum.Politics);
+        var newsCollection = CreateNewsObject(articles,SubjectEnum.Politics);
 
         return newsCollection;
     }
@@ -39,13 +39,13 @@ public class JornalBeiraRio(HttpClient httpclient)
         htmlDoc.LoadHtml(html); 
 
         var articles = htmlDoc.DocumentNode.SelectNodes("//article");
-        var newsCollection = await CreateNewsObject(articles,SubjectEnum.Health);
+        var newsCollection = CreateNewsObject(articles,SubjectEnum.Health);
 
         return newsCollection;
 
     }
 
-    private Task<News[]> CreateNewsObject(HtmlNodeCollection articles, SubjectEnum subject)
+    private News[] CreateNewsObject(HtmlNodeCollection articles, SubjectEnum subject)
     {
         var newsCollection = new List<News>();
 
@@ -75,6 +75,6 @@ public class JornalBeiraRio(HttpClient httpclient)
             newsCollection.Add(news);
         }
 
-        return Task.FromResult(newsCollection.ToArray());
+        return newsCollection.ToArray();
     }
 }

--- a/src/Core/News/DataSources/JornalBeiraRio.cs
+++ b/src/Core/News/DataSources/JornalBeiraRio.cs
@@ -25,7 +25,7 @@ public class JornalBeiraRio(HttpClient httpclient) : IDataSource
 
         var articles = htmlDoc.DocumentNode.SelectNodes("//article");
 
-        var newsCollection = CreateNewsObject(articles,SubjectEnum.Politics);
+        var newsCollection = CreateNewsObject(articles, SubjectEnum.Politics);
 
         return newsCollection;
     }

--- a/src/Core/News/DataSources/PortalDaCidade.cs
+++ b/src/Core/News/DataSources/PortalDaCidade.cs
@@ -1,0 +1,65 @@
+using Core.Extensions;
+using HtmlAgilityPack;
+
+namespace Core.News.DataSources;
+
+public class PortalDaCidade(HttpClient httpClient) : IDataSource
+{
+    private const string SourceName = "Portal da Cidade";
+    private const string SourceIconUrl = "https://resende.portaldacidade.com/static/favicon.ico";
+    
+    public async Task<News[]> GetNews()
+    {
+        var news = new List<News>();
+        news.AddRange(await GetCultureNews());
+        return news.ToArray();
+    }
+
+    private async Task<News[]> GetCultureNews()
+    {
+        var response = await httpClient.GetAsync("https://resende.portaldacidade.com/noticias/cultura");
+        var html = await response.Content.ReadAsStringAsync();
+        
+        var htmlDoc = new HtmlDocument();
+        htmlDoc.LoadHtml(html); 
+
+        var newsNode = htmlDoc.DocumentNode.SelectSingleNode("//div[@class='news-flex']");
+        var linkNodes = newsNode.SelectNodes(".//a");
+
+        var newsCollections = CreateNewsObject(linkNodes, SubjectEnum.Culture);
+        return newsCollections;
+    }
+
+    private News[] CreateNewsObject(HtmlNodeCollection linkNodes, SubjectEnum subject)
+    {
+        var newsCollection = new List<News>();
+        
+        foreach (var article in linkNodes)
+        {
+            var title = article.SelectSingleNode(".//h2").InnerText;
+            var link = article.GetAttributeValue("href", "");
+            var date = article.SelectSingleNode("//div[2]/p[3]").InnerText;
+            var content = article.SelectSingleNode("//div[2]/p[2]").InnerText;
+            var image = article.SelectSingleNode(".//img").GetAttributeValue("src", "");
+            
+            title = HtmlEntity.DeEntitize(title);
+            content = HtmlEntity.DeEntitize(content);
+            date = HtmlEntity.DeEntitize(date);
+            
+            date = date.ReturnStringBetween("Publicado em ", " às");
+            
+            var news = new News(
+                title,
+                content,
+                SourceName,
+                new Uri(SourceIconUrl),
+                subject,
+                DateTime.Parse(date),
+                new Uri(link),
+                new Uri(image));
+            newsCollection.Add(news);
+        }
+        
+        return newsCollection.ToArray();
+    }
+}

--- a/src/Core/News/DataSources/PrefeituraResende.cs
+++ b/src/Core/News/DataSources/PrefeituraResende.cs
@@ -1,0 +1,53 @@
+using System.Web;
+using HtmlAgilityPack;
+
+namespace Core.News.DataSources;
+
+public class PrefeituraResende(HttpClient httpClient) : IDataSource
+{
+    private const string SourceName = "Prefeitura de Resende";
+    public const string SourceIconUrl = "https://resende.rj.gov.br/images/logo.WebP";
+
+    public Task<News[]> GetNews() 
+        => GetNewsOfCurrentDay();
+
+    private async Task<News[]> GetNewsOfCurrentDay()
+    {
+        var dateFilter = DateTime.Now.ToString("dd/MM/yyyy");
+        var dateFilterEncoded = HttpUtility.UrlEncode(dateFilter);
+        
+        var response = await httpClient.GetAsync("https://resende.rj.gov.br/noticias?de=11%2F01%2F2024&page=1");
+        var html = await response.Content.ReadAsStringAsync();
+        
+        var htmlDoc = new HtmlDocument();
+        htmlDoc.LoadHtml(html); 
+
+        var pagination = htmlDoc.DocumentNode.SelectSingleNode("//div[@class='pagination']");
+        
+        if (!int.TryParse(pagination.SelectSingleNode(".//li[last()-1]//a").InnerText, out var totalPages)) 
+            return [];
+        
+        var news = new List<News>();
+        for (var i = 1; i <= totalPages; i++)
+        {
+            if (i > 1)
+            {
+                var responsePage = await httpClient.GetAsync($"https://resende.rj.gov.br/noticias?de={dateFilterEncoded}&page={i}");
+                html = await responsePage.Content.ReadAsStringAsync();
+            }
+            
+            var htmlDocPage = new HtmlDocument();
+            htmlDocPage.LoadHtml(html); 
+            var articles = htmlDocPage.DocumentNode.SelectNodes("//article");
+            var newsCollections = CreateNewsObject(articles);
+            news.AddRange(newsCollections);
+        }
+        return news.ToArray();
+
+    }
+
+    private News[] CreateNewsObject(HtmlNodeCollection articles)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Core/News/News.cs
+++ b/src/Core/News/News.cs
@@ -30,8 +30,8 @@ public sealed class News
     
     public News(string title, string content, string author, Uri authorIconUrl, SubjectEnum subject, DateTime publishedAt, Uri originalUrl, Uri? imageUrl)
     {
-        Title = title;
-        Content = content;
+        Title = title.Trim();
+        Content = content.Trim();
         Author = author;
         AuthorIconUrl = authorIconUrl;
         Subject = subject;
@@ -71,6 +71,7 @@ public sealed class News
             SubjectEnum.Economy => "Economia",
             SubjectEnum.Health => "Saúde",
             SubjectEnum.Woman => "Mulher",
+            SubjectEnum.Culture => "Cultura",
             _ => "Outros"
         };
     }

--- a/src/Core/News/News.cs
+++ b/src/Core/News/News.cs
@@ -72,7 +72,7 @@ public sealed class News
             SubjectEnum.Health => "Saúde",
             SubjectEnum.Woman => "Mulher",
             SubjectEnum.Culture => "Cultura",
-            _ => "Outros"
+            _ => "Indefinido"
         };
     }
 

--- a/src/Core/News/SubjectEnum.cs
+++ b/src/Core/News/SubjectEnum.cs
@@ -6,5 +6,6 @@ public enum SubjectEnum
     Health = 2,
     Sports = 3,
     Economy = 4,
-    Woman = 5
+    Woman = 5,
+    Culture = 6,
 }

--- a/src/Core/News/SubjectEnum.cs
+++ b/src/Core/News/SubjectEnum.cs
@@ -2,6 +2,7 @@ namespace Core.News;
 
 public enum SubjectEnum
 {
+    Undefined = 0,
     Politics = 1,
     Health = 2,
     Sports = 3,

--- a/src/UnitTests/PortalDaCidadeTests.cs
+++ b/src/UnitTests/PortalDaCidadeTests.cs
@@ -1,0 +1,24 @@
+using Core.News.DataSources;
+using Xunit.Abstractions;
+
+namespace UnitTests;
+
+public class PortalDaCidadeTests(ITestOutputHelper output)
+{
+
+    [Fact]
+    public async Task GetNews()
+    {   
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/132.0");
+        var jornalBeiraRio = new PortalDaCidade(httpClient);
+        var news = await jornalBeiraRio.GetNews();
+        Assert.True(news.Length > 0);
+
+        foreach (var n in news)
+        {
+            output.WriteLine(n.ToString());
+            output.WriteLine("====================================");
+        }
+    }
+}

--- a/src/UnitTests/PrefeituraResendeTests.cs
+++ b/src/UnitTests/PrefeituraResendeTests.cs
@@ -1,0 +1,25 @@
+using Core.News.DataSources;
+using Xunit.Abstractions;
+using HttpClient = System.Net.Http.HttpClient;
+
+namespace UnitTests;
+
+public class PrefeituraResendeTests(ITestOutputHelper output)
+{
+
+    [Fact]
+    public async Task GetNews()
+    {   
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/132.0");
+        var prefeituraResende = new PrefeituraResende(httpClient);
+        var news = await prefeituraResende.GetNews();
+        Assert.True(news.Length > 0);
+
+        foreach (var n in news)
+        {
+            output.WriteLine(n.ToString());
+            output.WriteLine("====================================");
+        }
+    }
+}


### PR DESCRIPTION
## Outras modificações:

- Criada interface `IDataSource` para ser implementada por qualquer fonte de notícia que seja adicionada
- Usado reflection para instanciar todas as fontes de notícia e chamar o método `GetNews()`
- Removido código assíncrono desnecessário